### PR TITLE
Fix wrong clicking behaviour for demonstrations

### DIFF
--- a/pres/NeuralNetworks.html
+++ b/pres/NeuralNetworks.html
@@ -26,6 +26,15 @@
 		<script src="../js/math.min.js"></script>
 
 		<style>
+			svg {
+				-webkit-touch-callout: none;
+				-webkit-user-select: none;
+				-khtml-user-select: none;
+				-moz-user-select: none;
+				-ms-user-select: none;
+				user-select: none;
+			}
+
 			.chart path {
 				stroke: steelblue;
 				fill: none;
@@ -885,6 +894,8 @@
 			// More info https://github.com/hakimel/reveal.js#configuration
 			Reveal.initialize({
 				history: true,
+				minScale: 1,
+				maxScale: 1,
 				// More info https://github.com/hakimel/reveal.js#dependencies
 				dependencies: [
 					{ src: '../plugin/markdown/marked.js' },


### PR DESCRIPTION
Due to issues with brower's calculations for on-screen positions of objects, `d3.mouse` returns incorrect values for some elements. This was easily fixed by disabling scaling on Reveal.js' side. Additionally, text selection in SVG elements was disabled completely to prevent funky looking text elements.
